### PR TITLE
Remove secure endpoint parameter, as of s3proxy 1.5 this requires two…

### DIFF
--- a/src/main/scala/com/localytics/sbt/s3/S3ProxyTasks.scala
+++ b/src/main/scala/com/localytics/sbt/s3/S3ProxyTasks.scala
@@ -40,7 +40,6 @@ object S3ProxyTasks {
         Seq(s"-Ds3proxy.authorization=$authorization") ++
         Seq(s"-Djclouds.filesystem.basedir=$dataDir") ++
         Seq(s"-Ds3proxy.endpoint=http://127.0.0.1:$port") ++
-        Seq(s"-Ds3proxy.secure-endpoint=https://127.0.0.1:$port") ++
         Seq("-jar", new File(downloadDir, downloadFile).getAbsolutePath) ++
         Seq("--properties", "/dev/null")
 


### PR DESCRIPTION
… more parameters to be passed as well.
