### PR TITLE
Change s3ProxyVersion from 1.5.0-prerelease to 1.5.0

### DIFF
--- a/src/main/scala/com/localytics/sbt/s3/S3ProxyPlugin.scala
+++ b/src/main/scala/com/localytics/sbt/s3/S3ProxyPlugin.scala
@@ -14,7 +14,7 @@ object S3ProxyPlugin extends AutoPlugin {
 
   // inject project settings http://www.scala-sbt.org/0.13/docs/Plugins.html#projectSettings+and+buildSettings
   override lazy val projectSettings = Seq(
-    s3ProxyVersion := "1.5.0-prerelease",
+    s3ProxyVersion := "1.5.0",
     s3ProxyDownloadDir := file("s3-proxy"),
     s3ProxyDownloadUrl := s"https://github.com/andrewgaul/s3proxy/releases/download/s3proxy-${s3ProxyVersion.value}/s3proxy",
     s3ProxyDownloadFile := s"s3proxy-${s3ProxyVersion.value}",


### PR DESCRIPTION
S3Proxy version 1.5.0 has just been released: https://github.com/andrewgaul/s3proxy/releases/tag/s3proxy-1.5.0